### PR TITLE
[feat]: speedy hash map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,6 +2471,7 @@ dependencies = [
  "hex",
  "once_cell",
  "poseidon-base",
+ "rustc-hash",
  "serde",
 ]
 
@@ -2616,6 +2617,12 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hex"

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -23,12 +23,13 @@ serde = { version = "1.0", default-features = false, features = [
 ], optional = true }
 
 [features]
-default = ["std"]
+default = ["std", "fxhash"]
 std = ["serde?/std", "revm-primitives/std"]
 serde = ["dep:serde", "revm-primitives/serde"]
 arbitrary = ["std", "revm-primitives/arbitrary"]
 asm-keccak = ["revm-primitives/asm-keccak"]
 portable = ["revm-primitives/portable"]
+fxhash = ["revm-primitives/fxhash"]
 
 optimism = ["revm-primitives/optimism"]
 # Optimism default handler enabled Optimism handler register by default in EvmBuilder.

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -38,7 +38,7 @@ criterion = { version = "0.5" }
 rand = { version = "0.8", features = ["std"] }
 
 [features]
-default = ["std", "c-kzg", "secp256k1", "portable"]
+default = ["std", "c-kzg", "secp256k1", "portable", "fxhash"]
 std = [
     "revm-primitives/std",
     "k256/std",
@@ -75,6 +75,8 @@ negate-scroll-default-handler = [
 # Enables the KZG point evaluation precompile.
 c-kzg = ["dep:c-kzg", "revm-primitives/c-kzg"]
 portable = ["revm-primitives/portable", "c-kzg?/portable"]
+
+fxhash = ["revm-primitives/fxhash"]
 
 # Use `secp256k1` as a faster alternative to `k256`.
 # The problem that `secp256k1` has is it fails to build for `wasm` target on Windows and Mac as it is c lib.

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -26,7 +26,7 @@ use once_cell::race::OnceBox;
 pub use revm_primitives as primitives;
 pub use revm_primitives::{
     precompile::{PrecompileError as Error, *},
-    Address, Bytes, HashMap, Log, B256,
+    Address, Bytes, HashMap, Log, TrustedHashMap, B256,
 };
 use std::{boxed::Box, vec::Vec};
 
@@ -53,7 +53,7 @@ impl PrecompileOutput {
 #[derive(Clone, Default, Debug)]
 pub struct Precompiles {
     /// Precompiles.
-    pub inner: HashMap<Address, Precompile>,
+    pub inner: TrustedHashMap<Address, Precompile>,
 }
 
 impl Precompiles {

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -21,6 +21,7 @@ alloy-primitives = { version = "0.7", default-features = false, features = [
     "rlp",
 ] }
 hashbrown = "0.14"
+rustc-hash = { version = "1.1", default-features = false, optional = true }
 auto_impl = "1.2"
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
 bitflags = { version = "2.5.0", default-features = false }
@@ -49,10 +50,11 @@ poseidon-base = { git = "https://github.com/scroll-tech/poseidon-circuit.git", b
 hex = { version = "0.4", default-features = false }
 
 [features]
-default = ["std", "c-kzg", "portable"]
+default = ["std", "c-kzg", "portable", "fxhash"]
 std = [
     "serde?/std",
     "alloy-primitives/std",
+    "rustc-hash?/std",
     "hex/std",
     "bitvec/std",
     "bitflags/std",
@@ -69,6 +71,7 @@ serde = [
 arbitrary = ["std", "alloy-primitives/arbitrary", "bitflags/arbitrary"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 portable = ["c-kzg?/portable"]
+fxhash = ["rustc-hash"]
 
 optimism = []
 # Optimism default handler enabled Optimism handler register by default in EvmBuilder.

--- a/crates/primitives/src/db.rs
+++ b/crates/primitives/src/db.rs
@@ -1,4 +1,4 @@
-use crate::{Account, AccountInfo, Address, Bytecode, HashMap, B256, U256};
+use crate::{Account, AccountInfo, Address, Bytecode, TrustedHashMap, B256, U256};
 use auto_impl::auto_impl;
 
 pub mod components;
@@ -29,7 +29,7 @@ pub trait Database {
 #[auto_impl(&mut, Box)]
 pub trait DatabaseCommit {
     /// Commit changes to the database.
-    fn commit(&mut self, changes: HashMap<Address, Account>);
+    fn commit(&mut self, changes: TrustedHashMap<Address, Account>);
 }
 
 /// EVM database interface.
@@ -93,7 +93,7 @@ impl<T: DatabaseRef> Database for WrapDatabaseRef<T> {
 
 impl<T: DatabaseRef + DatabaseCommit> DatabaseCommit for WrapDatabaseRef<T> {
     #[inline]
-    fn commit(&mut self, changes: HashMap<Address, Account>) {
+    fn commit(&mut self, changes: TrustedHashMap<Address, Account>) {
         self.0.commit(changes)
     }
 }

--- a/crates/primitives/src/db/components.rs
+++ b/crates/primitives/src/db/components.rs
@@ -7,7 +7,7 @@ pub use state::{State, StateRef};
 
 use crate::{
     db::{Database, DatabaseRef},
-    Account, AccountInfo, Address, Bytecode, HashMap, B256, U256,
+    Account, AccountInfo, Address, Bytecode, TrustedHashMap, B256, U256,
 };
 
 use super::DatabaseCommit;
@@ -77,7 +77,7 @@ impl<S: StateRef, BH: BlockHashRef> DatabaseRef for DatabaseComponents<S, BH> {
 }
 
 impl<S: DatabaseCommit, BH: BlockHashRef> DatabaseCommit for DatabaseComponents<S, BH> {
-    fn commit(&mut self, changes: HashMap<Address, Account>) {
+    fn commit(&mut self, changes: TrustedHashMap<Address, Account>) {
         self.state.commit(changes);
     }
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -31,7 +31,14 @@ pub use env::*;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
-        pub use std::collections::{hash_map, hash_set, HashMap, HashSet};
+        pub use std::collections::{hash_map, hash_set, HashSet};
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "fxhash")] {
+                pub use rustc_hash::FxHashMap as HashMap;
+            } else {
+                pub use std::collections::HashMap;
+            }
+        }
         use hashbrown as _;
     } else {
         pub use hashbrown::{hash_map, hash_set, HashMap, HashSet};

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -31,17 +31,26 @@ pub use env::*;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
-        pub use std::collections::{hash_map, hash_set, HashSet};
+        pub use std::collections::{hash_map, hash_set, HashMap, HashSet};
+
         cfg_if::cfg_if! {
             if #[cfg(feature = "fxhash")] {
-                pub use rustc_hash::FxHashMap as HashMap;
+                pub use rustc_hash::{
+                    FxHashMap as TrustedHashMap,
+                    FxHashSet as TrustedHashSet,
+                };
             } else {
-                pub use std::collections::HashMap;
+                pub use std::collections::{HashMap as TrustedHashMap, HashSet as TrustedHashSet};
             }
         }
+
         use hashbrown as _;
     } else {
         pub use hashbrown::{hash_map, hash_set, HashMap, HashSet};
+        pub use hashbrown::{HashMap as TrustedHashMap, HashSet as TrustedHashSet};
+
+        #[cfg(feature = "fxhash")]
+        use rustc_hash as _;
     }
 }
 

--- a/crates/primitives/src/state.rs
+++ b/crates/primitives/src/state.rs
@@ -1,4 +1,4 @@
-use crate::{Address, Bytecode, HashMap, B256, KECCAK_EMPTY, U256};
+use crate::{Address, Bytecode, HashMap, TrustedHashMap, B256, KECCAK_EMPTY, U256};
 use bitflags::bitflags;
 use core::hash::{Hash, Hasher};
 
@@ -6,10 +6,10 @@ use core::hash::{Hash, Hasher};
 use crate::POSEIDON_EMPTY;
 
 /// EVM State is a mapping from addresses to accounts.
-pub type State = HashMap<Address, Account>;
+pub type State = TrustedHashMap<Address, Account>;
 
 /// Structure used for EIP-1153 transient storage.
-pub type TransientStorage = HashMap<(Address, U256), U256>;
+pub type TransientStorage = TrustedHashMap<(Address, U256), U256>;
 
 /// An account's Storage is a mapping from 256-bit integer keys to [StorageSlot]s.
 pub type Storage = HashMap<U256, StorageSlot>;

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -47,7 +47,7 @@ criterion = "0.5"
 indicatif = "0.17"
 
 [features]
-default = ["std", "c-kzg", "secp256k1", "portable"]
+default = ["std", "c-kzg", "secp256k1", "portable", "fxhash"]
 std = [
     "serde?/std",
     "serde_json?/std",
@@ -60,6 +60,7 @@ serde-json = ["serde", "dep:serde_json"]
 arbitrary = ["revm-interpreter/arbitrary"]
 asm-keccak = ["revm-interpreter/asm-keccak", "revm-precompile/asm-keccak"]
 portable = ["revm-precompile/portable", "revm-interpreter/portable"]
+fxhash = ["revm-interpreter/fxhash", "revm-precompile/fxhash"]
 
 test-utils = []
 

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -487,7 +487,10 @@ mod test {
         let code = Bytecode::new_raw([0xEF, 0x00].into());
         #[cfg(feature = "scroll")]
         let poseidon_code_hash = code.poseidon_hash_slow();
+        #[cfg(feature = "scroll")]
         let keccak_code_hash = code.keccak_hash_slow();
+        #[cfg(not(feature = "scroll"))]
+        let keccak_code_hash = code.hash_slow();
         let to_addr = address!("ffffffffffffffffffffffffffffffffffffffff");
 
         // initialize the custom context and make sure it's zero
@@ -551,7 +554,10 @@ mod test {
         let code = Bytecode::new_raw([0xEF, 0x00].into());
         #[cfg(feature = "scroll")]
         let poseidon_code_hash = code.poseidon_hash_slow();
+        #[cfg(feature = "scroll")]
         let keccak_code_hash = code.keccak_hash_slow();
+        #[cfg(not(feature = "scroll"))]
+        let keccak_code_hash = code.hash_slow();
         let to_addr = address!("ffffffffffffffffffffffffffffffffffffffff");
 
         let mut evm = Evm::builder()

--- a/crates/revm/src/context/context_precompiles.rs
+++ b/crates/revm/src/context/context_precompiles.rs
@@ -1,6 +1,6 @@
 use crate::{
     precompile::{Precompile, PrecompileResult},
-    primitives::{db::Database, Address, Bytes, HashMap},
+    primitives::{db::Database, Address, Bytes, TrustedHashMap},
 };
 use core::ops::{Deref, DerefMut};
 use dyn_clone::DynClone;
@@ -33,7 +33,7 @@ impl<DB: Database> Clone for ContextPrecompile<DB> {
 
 #[derive(Clone)]
 pub struct ContextPrecompiles<DB: Database> {
-    inner: HashMap<Address, ContextPrecompile<DB>>,
+    inner: TrustedHashMap<Address, ContextPrecompile<DB>>,
 }
 
 impl<DB: Database> ContextPrecompiles<DB> {
@@ -83,7 +83,7 @@ impl<DB: Database> Default for ContextPrecompiles<DB> {
 }
 
 impl<DB: Database> Deref for ContextPrecompiles<DB> {
-    type Target = HashMap<Address, ContextPrecompile<DB>>;
+    type Target = TrustedHashMap<Address, ContextPrecompile<DB>>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/crates/revm/src/context/evm_context.rs
+++ b/crates/revm/src/context/evm_context.rs
@@ -396,7 +396,7 @@ mod tests {
                 nonce: 0,
                 balance: bal,
                 #[cfg(not(feature = "scroll"))]
-                code_hash: by.clone().keccak_hash_slow(),
+                code_hash: by.clone().hash_slow(),
                 #[cfg(feature = "scroll")]
                 code_hash: by.clone().poseidon_hash_slow(),
                 #[cfg(feature = "scroll")]

--- a/crates/revm/src/context/evm_context.rs
+++ b/crates/revm/src/context/evm_context.rs
@@ -4,7 +4,7 @@ use crate::{
     interpreter::{
         return_ok, CallInputs, Contract, Gas, InstructionResult, Interpreter, InterpreterResult,
     },
-    primitives::{Address, Bytes, EVMError, Env, HashSet, U256},
+    primitives::{Address, Bytes, EVMError, Env, TrustedHashSet, U256},
     ContextPrecompiles, FrameOrResult, CALL_STACK_LIMIT,
 };
 use core::{
@@ -93,8 +93,10 @@ impl<DB: Database> EvmContext<DB> {
     #[inline]
     pub fn set_precompiles(&mut self, precompiles: ContextPrecompiles<DB>) {
         // set warm loaded addresses.
-        self.journaled_state.warm_preloaded_addresses =
-            precompiles.addresses().copied().collect::<HashSet<_>>();
+        self.journaled_state.warm_preloaded_addresses = precompiles
+            .addresses()
+            .copied()
+            .collect::<TrustedHashSet<_>>();
         self.precompiles = precompiles;
     }
 
@@ -221,6 +223,7 @@ impl<DB: Database> EvmContext<DB> {
 #[cfg(any(test, feature = "test-utils"))]
 pub(crate) mod test_utils {
     use super::*;
+    use crate::primitives::TrustedHashSet;
     use crate::{
         db::{CacheDB, EmptyDB},
         journaled_state::JournaledState,
@@ -285,7 +288,7 @@ pub(crate) mod test_utils {
         EvmContext {
             inner: InnerEvmContext {
                 env,
-                journaled_state: JournaledState::new(SpecId::CANCUN, HashSet::new()),
+                journaled_state: JournaledState::new(SpecId::CANCUN, TrustedHashSet::default()),
                 db,
                 error: Ok(()),
                 #[cfg(any(feature = "optimism", feature = "scroll"))]
@@ -300,7 +303,7 @@ pub(crate) mod test_utils {
         EvmContext {
             inner: InnerEvmContext {
                 env,
-                journaled_state: JournaledState::new(SpecId::CANCUN, HashSet::new()),
+                journaled_state: JournaledState::new(SpecId::CANCUN, TrustedHashSet::default()),
                 db,
                 error: Ok(()),
                 #[cfg(any(feature = "optimism", feature = "scroll"))]

--- a/crates/revm/src/context/inner_evm_context.rs
+++ b/crates/revm/src/context/inner_evm_context.rs
@@ -7,9 +7,9 @@ use crate::{
     journaled_state::JournaledState,
     primitives::{
         keccak256, Account, Address, AnalysisKind, Bytecode, Bytes, CreateScheme, EVMError, Env,
-        HashSet, Spec,
+        Spec,
         SpecId::{self, *},
-        B256, U256,
+        TrustedHashSet, B256, U256,
     },
     FrameOrResult, JournalCheckpoint, CALL_STACK_LIMIT,
 };
@@ -56,7 +56,7 @@ impl<DB: Database> InnerEvmContext<DB> {
     pub fn new(db: DB) -> Self {
         Self {
             env: Box::default(),
-            journaled_state: JournaledState::new(SpecId::LATEST, HashSet::new()),
+            journaled_state: JournaledState::new(SpecId::LATEST, TrustedHashSet::default()),
             db,
             error: Ok(()),
             #[cfg(any(feature = "optimism", feature = "scroll"))]
@@ -69,7 +69,7 @@ impl<DB: Database> InnerEvmContext<DB> {
     pub fn new_with_env(db: DB, env: Box<Env>) -> Self {
         Self {
             env,
-            journaled_state: JournaledState::new(SpecId::LATEST, HashSet::new()),
+            journaled_state: JournaledState::new(SpecId::LATEST, TrustedHashSet::default()),
             db,
             error: Ok(()),
             #[cfg(any(feature = "optimism", feature = "scroll"))]

--- a/crates/revm/src/db/states/bundle_state.rs
+++ b/crates/revm/src/db/states/bundle_state.rs
@@ -6,7 +6,7 @@ use super::{
 use core::{mem, ops::RangeInclusive};
 use revm_interpreter::primitives::{
     hash_map::{self, Entry},
-    AccountInfo, Address, Bytecode, HashMap, HashSet, StorageSlot, TrustedHashMap, B256,
+    AccountInfo, Address, Bytecode, HashMap, StorageSlot, TrustedHashMap, TrustedHashSet, B256,
     KECCAK_EMPTY, U256,
 };
 use std::{
@@ -17,7 +17,7 @@ use std::{
 /// This builder is used to help to facilitate the initialization of `BundleState` struct
 #[derive(Debug)]
 pub struct BundleBuilder {
-    states: HashSet<Address>,
+    states: TrustedHashSet<Address>,
     state_original: TrustedHashMap<Address, AccountInfo>,
     state_present: TrustedHashMap<Address, AccountInfo>,
     state_storage: TrustedHashMap<Address, HashMap<U256, (U256, U256)>>,
@@ -55,7 +55,7 @@ impl OriginalValuesKnown {
 impl Default for BundleBuilder {
     fn default() -> Self {
         BundleBuilder {
-            states: HashSet::new(),
+            states: TrustedHashSet::default(),
             state_original: TrustedHashMap::default(),
             state_present: TrustedHashMap::default(),
             state_storage: TrustedHashMap::default(),
@@ -230,7 +230,7 @@ impl BundleBuilder {
     }
 
     /// Getter for `states` field
-    pub fn get_states(&self) -> &HashSet<Address> {
+    pub fn get_states(&self) -> &TrustedHashSet<Address> {
         &self.states
     }
 }

--- a/crates/revm/src/db/states/cache.rs
+++ b/crates/revm/src/db/states/cache.rs
@@ -2,7 +2,7 @@ use super::{
     plain_account::PlainStorage, transition_account::TransitionAccount, CacheAccount, PlainAccount,
 };
 use revm_interpreter::primitives::{
-    Account, AccountInfo, Address, Bytecode, HashMap, State as EVMState, B256,
+    Account, AccountInfo, Address, Bytecode, HashMap, State as EVMState, TrustedHashMap, B256,
 };
 use std::vec::Vec;
 
@@ -15,10 +15,10 @@ use std::vec::Vec;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CacheState {
     /// Block state account with account state
-    pub accounts: HashMap<Address, CacheAccount>,
+    pub accounts: TrustedHashMap<Address, CacheAccount>,
     /// created contracts
     /// TODO add bytecode counter for number of bytecodes added/removed.
-    pub contracts: HashMap<B256, Bytecode>,
+    pub contracts: TrustedHashMap<B256, Bytecode>,
     /// Has EIP-161 state clear enabled (Spurious Dragon hardfork).
     pub has_state_clear: bool,
 }

--- a/crates/revm/src/db/states/state.rs
+++ b/crates/revm/src/db/states/state.rs
@@ -5,7 +5,8 @@ use super::{
 use crate::db::EmptyDB;
 use revm_interpreter::primitives::{
     db::{Database, DatabaseCommit},
-    hash_map, Account, AccountInfo, Address, Bytecode, HashMap, B256, BLOCK_HASH_HISTORY, U256,
+    hash_map, Account, AccountInfo, Address, Bytecode, HashMap, TrustedHashMap, B256,
+    BLOCK_HASH_HISTORY, U256,
 };
 use std::{
     boxed::Box,
@@ -292,7 +293,7 @@ impl<DB: Database> Database for State<DB> {
 }
 
 impl<DB: Database> DatabaseCommit for State<DB> {
-    fn commit(&mut self, evm_state: HashMap<Address, Account>) {
+    fn commit(&mut self, evm_state: TrustedHashMap<Address, Account>) {
         let transitions = self.cache.apply_evm_state(evm_state);
         self.apply_transition(transitions);
     }
@@ -763,7 +764,7 @@ mod tests {
 
         assert_eq!(
             bundle_state.state,
-            HashMap::from([(
+            TrustedHashMap::from_iter([(
                 existing_account_address,
                 BundleAccount {
                     info: Some(existing_account_info.clone()),

--- a/crates/revm/src/db/states/transition_state.rs
+++ b/crates/revm/src/db/states/transition_state.rs
@@ -1,17 +1,18 @@
 use super::TransitionAccount;
-use revm_interpreter::primitives::{hash_map::Entry, Address, HashMap};
+use revm_interpreter::primitives::{hash_map::Entry, Address};
+use revm_precompile::TrustedHashMap;
 use std::vec::Vec;
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct TransitionState {
     /// Block state account with account state
-    pub transitions: HashMap<Address, TransitionAccount>,
+    pub transitions: TrustedHashMap<Address, TransitionAccount>,
 }
 
 impl TransitionState {
     /// Create new transition state with one transition.
     pub fn single(address: Address, transition: TransitionAccount) -> Self {
-        let mut transitions = HashMap::new();
+        let mut transitions = TrustedHashMap::default();
         transitions.insert(address, transition);
         TransitionState { transitions }
     }

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -1,7 +1,7 @@
 use crate::interpreter::{InstructionResult, SelfDestructResult};
 use crate::primitives::{
-    db::Database, hash_map::Entry, Account, Address, Bytecode, EVMError, HashSet, Log, SpecId::*,
-    State, StorageSlot, TransientStorage, TrustedHashMap, KECCAK_EMPTY, PRECOMPILE3, U256,
+    db::Database, hash_map::Entry, Account, Address, Bytecode, EVMError, Log, SpecId::*, State,
+    StorageSlot, TransientStorage, TrustedHashMap, TrustedHashSet, KECCAK_EMPTY, PRECOMPILE3, U256,
 };
 use core::mem;
 use revm_interpreter::primitives::SpecId;
@@ -36,7 +36,7 @@ pub struct JournaledState {
     ///
     /// Note that this not include newly loaded accounts, account and storage
     /// is considered warm if it is found in the `State`.
-    pub warm_preloaded_addresses: HashSet<Address>,
+    pub warm_preloaded_addresses: TrustedHashSet<Address>,
 }
 
 impl JournaledState {
@@ -51,7 +51,7 @@ impl JournaledState {
     /// # Note
     ///
     ///
-    pub fn new(spec: SpecId, warm_preloaded_addresses: HashSet<Address>) -> JournaledState {
+    pub fn new(spec: SpecId, warm_preloaded_addresses: TrustedHashSet<Address>) -> JournaledState {
         Self {
             state: TrustedHashMap::default(),
             transient_storage: TransientStorage::default(),

--- a/crates/revm/src/journaled_state.rs
+++ b/crates/revm/src/journaled_state.rs
@@ -1,7 +1,7 @@
 use crate::interpreter::{InstructionResult, SelfDestructResult};
 use crate::primitives::{
-    db::Database, hash_map::Entry, Account, Address, Bytecode, EVMError, HashMap, HashSet, Log,
-    SpecId::*, State, StorageSlot, TransientStorage, KECCAK_EMPTY, PRECOMPILE3, U256,
+    db::Database, hash_map::Entry, Account, Address, Bytecode, EVMError, HashSet, Log, SpecId::*,
+    State, StorageSlot, TransientStorage, TrustedHashMap, KECCAK_EMPTY, PRECOMPILE3, U256,
 };
 use core::mem;
 use revm_interpreter::primitives::SpecId;
@@ -53,7 +53,7 @@ impl JournaledState {
     ///
     pub fn new(spec: SpecId, warm_preloaded_addresses: HashSet<Address>) -> JournaledState {
         Self {
-            state: HashMap::new(),
+            state: TrustedHashMap::default(),
             transient_storage: TransientStorage::default(),
             logs: Vec::new(),
             journal: vec![vec![]],


### PR DESCRIPTION
# Motivation

Rust uses `SipHash` by default, which provides resistance against DOS attacks with compromise of speed.

The Fx algorithm is a speedy, non-cryptographic hashing algorithm used by rustc and Firefox.

## Changes

Introduce `fxhash` feature gate and two type alias: `TrustedHashMap` and `TrustedHashSet`.

## Concern

For HashMap/HashSet that use address or code hash as a key, there’s usually a satisfactory distribution on H160/H256. The storage key, though, can be manipulated by attackers so HashMap/HashSet that use the storage key cannot be replaced by fxhash. Additionally, in certain circumstances, attackers could potentially manipulate the address, as in the callee, despite the CALL gas being payable for each attempt.