### PR TITLE
[feat]: speedy hash map

### DIFF
--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -29,6 +29,7 @@ serde = ["dep:serde", "revm-primitives/serde"]
 arbitrary = ["std", "revm-primitives/arbitrary"]
 asm-keccak = ["revm-primitives/asm-keccak"]
 portable = ["revm-primitives/portable"]
+faster-hash = ["revm-primitives/faster-hash"]
 
 optimism = ["revm-primitives/optimism"]
 # Optimism default handler enabled Optimism handler register by default in EvmBuilder.

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -81,6 +81,8 @@ portable = ["revm-primitives/portable", "c-kzg?/portable"]
 # In Linux it passes. If you don't require to build wasm on win/mac, it is safe to use it and it is enabled by default.
 secp256k1 = ["dep:secp256k1"]
 
+faster-hash = ["revm-primitives/faster-hash"]
+
 [[bench]]
 name = "bench"
 path = "benches/bench.rs"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -69,6 +69,7 @@ serde = [
 arbitrary = ["std", "alloy-primitives/arbitrary", "bitflags/arbitrary"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
 portable = ["c-kzg?/portable"]
+faster-hash = ["hashbrown/ahash"]
 
 optimism = []
 # Optimism default handler enabled Optimism handler register by default in EvmBuilder.

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -30,7 +30,9 @@ pub use constants::*;
 pub use env::*;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
+    if #[cfg(feature = "faster-hash")] {
+        pub use hashbrown::{hash_map, hash_set, HashMap, HashSet};
+    } else if #[cfg(feature = "std")] {
         pub use std::collections::{hash_map, hash_set, HashMap, HashSet};
         use hashbrown as _;
     } else {

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -60,6 +60,7 @@ serde-json = ["serde", "dep:serde_json"]
 arbitrary = ["revm-interpreter/arbitrary"]
 asm-keccak = ["revm-interpreter/asm-keccak", "revm-precompile/asm-keccak"]
 portable = ["revm-precompile/portable", "revm-interpreter/portable"]
+faster-hash = ["revm-interpreter/faster-hash", "revm-precompile/faster-hash"]
 
 test-utils = []
 


### PR DESCRIPTION
# Motivation

Rust uses `SipHash` by default, while hashbrown already uses faster [`ahash`](https://github.com/rust-lang/hashbrown?tab=readme-ov-file#performance) instead

## Changes

Introduce `faster-hash` feature gate.