### PR TITLE
feat: minimize diff to upstream

### DIFF
--- a/bins/revm-test/src/bin/burntpix/main.rs
+++ b/bins/revm-test/src/bin/burntpix/main.rs
@@ -100,22 +100,11 @@ fn try_from_hex_to_u32(hex: &str) -> eyre::Result<u32> {
 }
 
 fn insert_account_info(cache_db: &mut CacheDB<EmptyDB>, addr: Address, code: Bytes) {
-    let keccak256_code_hash = hex::encode(keccak256(&code));
-    #[cfg(feature = "scroll-poseidon-codehash")]
-    let poseidon_code_hash = hex::encode(revm::primitives::poseidon(&code));
-    #[cfg(not(feature = "scroll-poseidon-codehash"))]
+    let code_hash = hex::encode(keccak256(&code));
     let account_info = AccountInfo::new(
         U256::from(0),
         0,
-        B256::from_str(&keccak256_code_hash).unwrap(),
-        Bytecode::new_raw(code),
-    );
-    #[cfg(feature = "scroll-poseidon-codehash")]
-    let account_info = AccountInfo::new(
-        U256::from(0),
-        0,
-        B256::from_str(&poseidon_code_hash).unwrap(),
-        B256::from_str(&keccak256_code_hash).unwrap(),
+        B256::from_str(&code_hash).unwrap(),
         Bytecode::new_raw(code),
     );
     cache_db.insert_account_info(addr, account_info);

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -267,12 +267,9 @@ pub fn execute_test_suite(
                 balance: info.balance,
                 #[cfg(feature = "scroll")]
                 code_size,
-                #[cfg(not(feature = "scroll-poseidon-codehash"))]
                 code_hash: keccak_code_hash,
                 #[cfg(feature = "scroll-poseidon-codehash")]
-                code_hash: poseidon_code_hash,
-                #[cfg(feature = "scroll-poseidon-codehash")]
-                keccak_code_hash,
+                poseidon_code_hash,
                 code: Some(bytecode),
                 nonce: info.nonce,
             };

--- a/crates/interpreter/src/host.rs
+++ b/crates/interpreter/src/host.rs
@@ -32,10 +32,6 @@ pub trait Host {
     /// Get code size of `address` and if the account is cold.
     fn code_size(&mut self, address: Address) -> Option<(usize, bool)>;
 
-    #[cfg(feature = "scroll-poseidon-codehash")]
-    /// Get keccak code hash of `address` and if the account is cold.
-    fn keccak_code_hash(&mut self, address: Address) -> Option<(B256, bool)>;
-
     /// Get storage value of `address` at `index` and if the account is cold.
     fn sload(&mut self, address: Address, index: U256) -> Option<(U256, bool)>;
 

--- a/crates/interpreter/src/host/dummy.rs
+++ b/crates/interpreter/src/host/dummy.rs
@@ -71,22 +71,7 @@ impl Host for DummyHost {
     }
 
     #[inline]
-    #[cfg(not(feature = "scroll-poseidon-codehash"))]
     fn code_hash(&mut self, _address: Address) -> Option<(B256, bool)> {
-        Some((KECCAK_EMPTY, false))
-    }
-
-    #[inline]
-    #[cfg(feature = "scroll-poseidon-codehash")]
-    fn code_hash(&mut self, _address: Address) -> Option<(B256, bool)> {
-        use revm_primitives::POSEIDON_EMPTY;
-
-        Some((POSEIDON_EMPTY, false))
-    }
-
-    #[inline]
-    #[cfg(feature = "scroll-poseidon-codehash")]
-    fn keccak_code_hash(&mut self, _address: Address) -> Option<(B256, bool)> {
         Some((KECCAK_EMPTY, false))
     }
 

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -74,13 +74,7 @@ pub fn extcodesize<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, 
 pub fn extcodehash<H: Host + ?Sized, SPEC: Spec>(interpreter: &mut Interpreter, host: &mut H) {
     check!(interpreter, CONSTANTINOPLE);
     pop_address!(interpreter, address);
-
-    #[cfg(not(feature = "scroll-poseidon-codehash"))]
-    let result = host.code_hash(address);
-    #[cfg(feature = "scroll-poseidon-codehash")]
-    let result = host.keccak_code_hash(address);
-
-    let Some((code_hash, is_cold)) = result else {
+    let Some((code_hash, is_cold)) = host.code_hash(address) else {
         interpreter.instruction_result = InstructionResult::FatalExternalError;
         return;
     };

--- a/crates/primitives/src/bytecode.rs
+++ b/crates/primitives/src/bytecode.rs
@@ -46,32 +46,22 @@ impl Bytecode {
 
     /// Calculate hash of the bytecode.
     pub fn hash_slow(&self) -> B256 {
-        cfg_if::cfg_if! {
-            if #[cfg(not(feature = "scroll-poseidon-codehash"))] {
-                if self.is_empty() {
-                    KECCAK_EMPTY
-                } else {
-                    keccak256(self.original_byte_slice())
-                }
-            } else {
-                use crate::{poseidon, POSEIDON_EMPTY};
-
-                if self.is_empty() {
-                    POSEIDON_EMPTY
-                } else {
-                    poseidon(self.original_byte_slice())
-                }
-            }
-        }
-    }
-
-    /// Calculate keccak hash of the bytecode.
-    #[cfg(feature = "scroll-poseidon-codehash")]
-    pub fn keccak_hash_slow(&self) -> B256 {
         if self.is_empty() {
             KECCAK_EMPTY
         } else {
             keccak256(self.original_byte_slice())
+        }
+    }
+
+    /// Calculate poseidon hash of the bytecode.
+    #[cfg(feature = "scroll-poseidon-codehash")]
+    pub fn poseidon_hash_slow(&self) -> B256 {
+        use crate::{poseidon, POSEIDON_EMPTY};
+
+        if self.is_empty() {
+            POSEIDON_EMPTY
+        } else {
+            poseidon(self.original_byte_slice())
         }
     }
 

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -8,8 +8,8 @@ pub use handler_cfg::{CfgEnvWithHandlerCfg, EnvWithHandlerCfg, HandlerCfg};
 
 use crate::{
     calc_blob_gasprice, AccessListItem, Account, Address, Bytes, InvalidHeader, InvalidTransaction,
-    Spec, SpecId, B256, GAS_PER_BLOB, MAX_BLOB_NUMBER_PER_BLOCK, MAX_CODE_SIZE, MAX_INITCODE_SIZE,
-    U256, VERSIONED_HASH_VERSION_KZG,
+    Spec, SpecId, B256, GAS_PER_BLOB, KECCAK_EMPTY, MAX_BLOB_NUMBER_PER_BLOCK, MAX_CODE_SIZE,
+    MAX_INITCODE_SIZE, U256, VERSIONED_HASH_VERSION_KZG,
 };
 use alloy_primitives::TxKind;
 use core::cmp::{min, Ordering};
@@ -227,20 +227,8 @@ impl Env {
         // EIP-3607: Reject transactions from senders with deployed code
         // This EIP is introduced after london but there was no collision in past
         // so we can leave it enabled always
-        cfg_if::cfg_if! {
-            if #[cfg(not(feature = "scroll-poseidon-codehash"))] {
-                use crate::KECCAK_EMPTY;
-
-                if !self.cfg.is_eip3607_disabled() && account.info.code_hash != KECCAK_EMPTY {
-                    return Err(InvalidTransaction::RejectCallerWithCode);
-                }
-            } else {
-                use crate::POSEIDON_EMPTY;
-
-                if !self.cfg.is_eip3607_disabled() && account.info.code_hash != POSEIDON_EMPTY {
-                    return Err(InvalidTransaction::RejectCallerWithCode);
-                }
-            }
+        if !self.cfg.is_eip3607_disabled() && account.info.code_hash != KECCAK_EMPTY {
+            return Err(InvalidTransaction::RejectCallerWithCode);
         }
 
         // Check that the transaction's nonce is correct

--- a/crates/revm/src/builder.rs
+++ b/crates/revm/src/builder.rs
@@ -487,8 +487,6 @@ mod test {
     fn simple_add_stateful_instruction() {
         let code = Bytecode::new_raw([0xED, 0x00].into());
         let code_hash = code.hash_slow();
-        #[cfg(feature = "scroll-poseidon-codehash")]
-        let keccak_code_hash = code.keccak_hash_slow();
         let to_addr = address!("ffffffffffffffffffffffffffffffffffffffff");
 
         // initialize the custom context and make sure it's zero
@@ -499,11 +497,7 @@ mod test {
         let mut evm = Evm::builder()
             .with_db(InMemoryDB::default())
             .modify_db(|db| {
-                #[cfg(not(feature = "scroll-poseidon-codehash"))]
-                let acc = AccountInfo::new(U256::ZERO, 0, code_hash, code);
-                #[cfg(feature = "scroll-poseidon-codehash")]
-                let acc = AccountInfo::new(U256::ZERO, 0, code_hash, keccak_code_hash, code);
-                db.insert_account_info(to_addr, acc)
+                db.insert_account_info(to_addr, AccountInfo::new(U256::ZERO, 0, code_hash, code))
             })
             .modify_tx_env(|tx| tx.transact_to = TxKind::Call(to_addr))
             // we need to use handle register box to capture the custom context in the handle
@@ -547,18 +541,12 @@ mod test {
 
         let code = Bytecode::new_raw([0xED, 0x00].into());
         let code_hash = code.hash_slow();
-        #[cfg(feature = "scroll-poseidon-codehash")]
-        let keccak_code_hash = code.keccak_hash_slow();
         let to_addr = address!("ffffffffffffffffffffffffffffffffffffffff");
 
         let mut evm = Evm::builder()
             .with_db(InMemoryDB::default())
             .modify_db(|db| {
-                #[cfg(not(feature = "scroll-poseidon-codehash"))]
-                let acc = AccountInfo::new(U256::ZERO, 0, code_hash, code);
-                #[cfg(feature = "scroll-poseidon-codehash")]
-                let acc = AccountInfo::new(U256::ZERO, 0, code_hash, keccak_code_hash, code);
-                db.insert_account_info(to_addr, acc)
+                db.insert_account_info(to_addr, AccountInfo::new(U256::ZERO, 0, code_hash, code))
             })
             .modify_tx_env(|tx| tx.transact_to = TxKind::Call(to_addr))
             .append_handler_register(|handler| {

--- a/crates/revm/src/context.rs
+++ b/crates/revm/src/context.rs
@@ -168,14 +168,6 @@ impl<EXT, DB: Database> Host for Context<EXT, DB> {
             .ok()
     }
 
-    #[cfg(feature = "scroll-poseidon-codehash")]
-    fn keccak_code_hash(&mut self, address: Address) -> Option<(B256, bool)> {
-        self.evm
-            .keccak_code_hash(address)
-            .map_err(|e| self.evm.error = Err(e))
-            .ok()
-    }
-
     fn sload(&mut self, address: Address, index: U256) -> Option<(U256, bool)> {
         self.evm
             .sload(address, index)

--- a/crates/revm/src/context/evm_context.rs
+++ b/crates/revm/src/context/evm_context.rs
@@ -625,7 +625,7 @@ mod tests {
                 code_size: by.len(),
                 code_hash: by.clone().hash_slow(),
                 #[cfg(feature = "scroll-poseidon-codehash")]
-                keccak_code_hash: by.clone().keccak_hash_slow(),
+                poseidon_code_hash: by.clone().poseidon_hash_slow(),
                 code: Some(by),
             },
         );

--- a/crates/revm/src/context/inner_evm_context.rs
+++ b/crates/revm/src/context/inner_evm_context.rs
@@ -222,20 +222,6 @@ impl<DB: Database> InnerEvmContext<DB> {
         Ok((acc.info.code_hash, is_cold))
     }
 
-    /// Get keccak code hash of address.
-    #[inline]
-    #[cfg(feature = "scroll-poseidon-codehash")]
-    pub fn keccak_code_hash(
-        &mut self,
-        address: Address,
-    ) -> Result<(B256, bool), EVMError<DB::Error>> {
-        let (acc, is_cold) = self.journaled_state.load_code(address, &mut self.db)?;
-        if acc.is_empty() {
-            return Ok((B256::ZERO, is_cold));
-        }
-        Ok((acc.info.keccak_code_hash, is_cold))
-    }
-
     /// Load storage slot, if storage is not present inside the account then it will be loaded from database.
     #[inline]
     pub fn sload(

--- a/crates/revm/src/db/alloydb.rs
+++ b/crates/revm/src/db/alloydb.rs
@@ -119,14 +119,7 @@ impl<T: Transport + Clone, N: Network, P: Provider<T, N>> DatabaseRef for AlloyD
         let code_hash = code.hash_slow();
         let nonce = nonce?;
 
-        cfg_if::cfg_if! {
-            if #[cfg(not(feature = "scroll-poseidon-codehash"))] {
-                Ok(Some(AccountInfo::new(balance, nonce, code_hash, code)))
-            } else {
-                let keccak_code_hash = code.keccak_hash_slow();
-                Ok(Some(AccountInfo::new(balance, nonce, code_hash, keccak_code_hash, code)))
-            }
-        }
+        Ok(Some(AccountInfo::new(balance, nonce, code_hash, code)))
     }
 
     fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {

--- a/crates/revm/src/db/ethersdb.rs
+++ b/crates/revm/src/db/ethersdb.rs
@@ -127,14 +127,7 @@ impl<M: Middleware> DatabaseRef for EthersDB<M> {
         let nonce = nonce?.as_u64();
         let bytecode = Bytecode::new_raw(code?.0.into());
         let code_hash = bytecode.hash_slow();
-        cfg_if::cfg_if! {
-            if #[cfg(not(feature = "scroll-poseidon-codehash"))] {
-                Ok(Some(AccountInfo::new(balance, nonce, code_hash, bytecode)))
-            } else {
-                let keccak_code_hash = bytecode.keccak_hash_slow();
-                Ok(Some(AccountInfo::new(balance, nonce, code_hash, keccak_code_hash, bytecode)))
-            }
-        }
+        Ok(Some(AccountInfo::new(balance, nonce, code_hash, bytecode)))
     }
 
     fn code_by_hash_ref(&self, _code_hash: B256) -> Result<Bytecode, Self::Error> {

--- a/crates/revm/src/handler/mainnet/post_execution.rs
+++ b/crates/revm/src/handler/mainnet/post_execution.rs
@@ -105,6 +105,10 @@ pub fn output<EXT, DB: Database>(
             .expect("Authorized account must exist");
         account.info.code = Some(Bytecode::default());
         account.info.code_hash = KECCAK_EMPTY;
+        #[cfg(feature = "scroll-poseidon-codehash")]
+        {
+            account.info.poseidon_code_hash = crate::primitives::POSEIDON_EMPTY;
+        }
     }
 
     let result = match instruction_result.result.into() {

--- a/crates/revm/src/handler/mainnet/pre_execution.rs
+++ b/crates/revm/src/handler/mainnet/pre_execution.rs
@@ -96,8 +96,6 @@ pub fn load_accounts<SPEC: Spec, EXT, DB: Database>(
                     .load_code(authorization.address, &mut context.evm.inner.db)?;
                 let code = account.info.code.clone();
                 let code_hash = account.info.code_hash;
-                #[cfg(feature = "scroll-poseidon-codehash")]
-                let keccak_code_hash = account.info.keccak_code_hash;
 
                 // If code is empty no need to set code or add it to valid
                 // authorizations, as it is a noop operation.
@@ -110,8 +108,6 @@ pub fn load_accounts<SPEC: Spec, EXT, DB: Database>(
                     authority,
                     code.unwrap_or_default(),
                     code_hash,
-                    #[cfg(feature = "scroll-poseidon-codehash")]
-                    keccak_code_hash,
                 );
 
                 valid_auths.push(authority);

--- a/crates/revm/src/inspector/customprinter.rs
+++ b/crates/revm/src/inspector/customprinter.rs
@@ -134,12 +134,9 @@ mod test {
                     balance: "0x100c5d668240db8e00".parse().unwrap(),
                     #[cfg(feature = "scroll")]
                     code_size: code.len(),
-                    #[cfg(not(feature = "scroll-poseidon-codehash"))]
                     code_hash: crate::primitives::keccak256(&code),
                     #[cfg(feature = "scroll-poseidon-codehash")]
-                    code_hash: crate::primitives::poseidon(&code),
-                    #[cfg(feature = "scroll-poseidon-codehash")]
-                    keccak_code_hash: crate::primitives::keccak256(&code),
+                    poseidon_code_hash: crate::primitives::poseidon(&code),
                     code: Some(crate::primitives::Bytecode::new_raw(code.clone())),
                     nonce: 1,
                 };


### PR DESCRIPTION
This pr removes previous patch to any function signature / traits related to poseidon.

In this version, poseidon_code_hash will be calculated every time code is updated. Since the evm execution path is not related to poseidon_code_hash, previous modifications are removed to minimize diff to upstream.